### PR TITLE
crash fix entity on NBCraft

### DIFF
--- a/src/entity/Entity.php
+++ b/src/entity/Entity.php
@@ -1157,24 +1157,19 @@ class Entity extends Position
 			16 => [
 				"type" => 0,
 				"value" => 0
-			],
-			17 => [
-				"type" => 6,
-				"value" => [
-					0,
-					0,
-					0
-				]
 			]
 		];
 		$d[16]["value"] = $this->data["State"];
 		if($this->isPlayer()){
 			if($this->player->isSleeping !== false){
 				$d[16]["value"] = 2;
-				$d[17]["value"] = [
-					$this->player->isSleeping->x,
-					$this->player->isSleeping->y,
-					$this->player->isSleeping->z
+				$d[17] = [
+					"type" => 6,
+					"value" => [
+						$this->player->isSleeping->x,
+						$this->player->isSleeping->y,
+						$this->player->isSleeping->z
+					]
 				];
 			}
 		}


### PR DESCRIPTION
fix(entity): don't send tilepos metadata (field 17) until the player is asleep

Field 17 (type 6 / tilepos — bed position) was always present in Entity::getMetadata(). Its header byte on the wire = (6<<5)|17 = 0xD1 (209). Clients reading the header as a signed int8 (NBCraft) receive (int8)209 >> 5 = -2, which doesn't match any DataType → the DataItem pointer remains null → crash on the subsequent getId() (read at address 0x4). Now field 17 is only sent when the player is actually asleep, as in real MCPE 0.3.x.